### PR TITLE
[BUGFIX] Hide Before/After Dates indexed with PHP timezone

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -76,7 +76,7 @@
           type: date
           include_in_all: false
           format: 'date_time_no_millis'
-        indexing: '${(node.hiddenBeforeDateTime ? Date.format(node.hiddenBeforeDateTime, "Y-m-d\TH:i:s") + "Z" : null)}'
+        indexing: '${(node.hiddenBeforeDateTime ? Date.format(node.hiddenBeforeDateTime, "Y-m-d\TH:i:sP") : null)}'
 
 
     '_hiddenAfterDateTime':
@@ -85,7 +85,7 @@
           type: date
           include_in_all: false
           format: 'date_time_no_millis'
-        indexing: '${(node.hiddenAfterDateTime ? Date.format(node.hiddenAfterDateTime, "Y-m-d\TH:i:s") + "Z" : null)}'
+        indexing: '${(node.hiddenAfterDateTime ? Date.format(node.hiddenAfterDateTime, "Y-m-d\TH:i:sP") : null)}'
 
 
 'TYPO3.Neos:Document':


### PR DESCRIPTION
Changed the "_hiddenBeforeDateTime" and "_hiddenAfterDateTime" Search Index Configuration to give over
the PHP's currently configured Timezone. That way, considering everything is configured correctly in the server
(same locale as PHP), "now" and all other queries should work as expected.

Related: Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor#70